### PR TITLE
Add Eliza-style chatbot assistant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+The SvelteKit app lives in `src/`. Routes follow `src/routes/**/+page.svelte` and companion `+page.ts` or `+server.ts`. Shared UI sits in `src/lib/components`, database helpers in `src/lib/db`, and runtime config in `src/lib/config.ts`. Public assets belong in `static/` (e.g., `static/images/<category>`), build artifacts in `build/`, and operational scripts in `scripts/`. Environment defaults stay in `.env`, and SQLite data is persisted in `data/db.sqlite`.
+
+## Build, Test, and Development Commands
+Use `npm run dev` to start the Vite dev server (`npm run dev -- --open` auto-opens a browser). Build production bundles with `npm run build`, then inspect via `npm run preview`. `npm run check` executes Svelte + TypeScript checks, while `npm run lint` and `npm run format` run Prettier and Tailwind sorting. Database workflows are handled through `npm run db:init | wipe | seed | export | reset`. Confirm the dev server with `npm run health`. Docker users can run `npm run docker:build` then `npm run docker:run`.
+
+## Coding Style & Naming Conventions
+Code is TypeScript, Svelte 5, and Tailwind 4 with two-space indentation. Prefer `$lib/...` imports for shared modules. Component files use PascalCase in `src/lib/components`, while routes rely on SvelteKit naming (`+page.*`, `+layout.*`). Always run `npm run format` before committing; Prettier 3 with `prettier-plugin-svelte` and `prettier-plugin-tailwindcss` enforces style.
+
+## Testing Guidelines
+No unit test framework ships yet; add Vitest when introducing automated tests. Place specs alongside sources as `*.spec.ts` (e.g., `src/lib/utils/foo.spec.ts`). Keep API route tests deterministic by mocking the DB or using an in-memory SQLite file. Document manual test steps in pull requests when automated coverage is absent.
+
+## Commit & Pull Request Guidelines
+Write commits in imperative mood with concise subjects ≤72 characters and optional rationale bodies. Pull requests should link issues when available, explain scope, list verification steps, and include screenshots or GIFs for UI updates. Note any database or environment changes explicitly and keep diffs focused.
+
+## Security & Configuration Tips
+Never commit secrets; read configuration from `.env`. When exposing API routes under `src/routes/api`, validate inputs and avoid revealing internal error details. Use `npm run db:reset` to rebuild the local SQLite database and ensure migrations stay reproducible.

--- a/src/lib/chat/eliza.ts
+++ b/src/lib/chat/eliza.ts
@@ -1,0 +1,148 @@
+export type ChatMessage = {
+	from: 'user' | 'bot';
+	text: string;
+};
+
+const reflections = new Map<string, string>([
+	['am', 'are'],
+	["i'm", 'you are'],
+	['i', 'you'],
+	['me', 'you'],
+	['my', 'your'],
+	['mine', 'yours'],
+	['you', 'I'],
+	['your', 'my'],
+	['yours', 'mine'],
+	['are', 'am']
+]);
+
+const patterns: Array<{ pattern: RegExp; responses: string[] }> = [
+	{
+		pattern: /\b(i need|i want|i would like)\b(?:.*)/i,
+		responses: [
+			'Why do you need $1?',
+			'Would having $1 really solve your concerns?',
+			'What would it mean if you got $1?'
+		]
+	},
+	{
+		pattern: /\b(i feel|i am feeling)\b(?:.*)/i,
+		responses: [
+			'What makes you feel that way?',
+			'Do these feelings surprise you?',
+			'How long have you been feeling this?'
+		]
+	},
+	{
+		pattern: /\b(i am|i'm) (.*)/i,
+		responses: [
+			'How does being $2 make you feel?',
+			'Why do you say you are $2?',
+			'Do you want to be $2?'
+		]
+	},
+	{
+		pattern: /\b(because)\b(?:.*)/i,
+		responses: [
+			'Is that the real reason?',
+			'What other reasons come to mind?',
+			'Does that reason feel satisfying to you?'
+		]
+	},
+	{
+		pattern: /\b(yes|yeah|yep)\b/i,
+		responses: [
+			'I see. Can you elaborate?',
+			'What else comes to mind?',
+			'Under what circumstances would that change?'
+		]
+	},
+	{
+		pattern: /\bno\b/i,
+		responses: [
+			'Why not?',
+			'What would make you say yes?',
+			'Can you explain that a bit more?'
+		]
+	},
+	{
+		pattern: /\b(customer support|support|help)\b/i,
+		responses: [
+			'What kind of support are you looking for?',
+			'Can you describe the issue you are facing with your order?',
+			'Have you checked the order status page in your account?'
+		]
+	},
+	{
+		pattern: /\b(order|shipping|delivery)\b/i,
+		responses: [
+			'Are you asking about a recent order?',
+			'When was the order placed?'
+		]
+	},
+	{
+		pattern: /\b(price|cost|expensive|cheap)\b/i,
+		responses: [
+			'What price range did you have in mind?',
+			'Is your concern about the total cost or shipping fees?'
+		]
+	},
+	{
+		pattern: /\b(can you|could you|would you)\b(?:.*)/i,
+		responses: [
+			'What makes you think I can $1?',
+			'How would you feel if I could $1?'
+		]
+	},
+	{
+		pattern: /\bwhy\b(?:.*)/i,
+		responses: [
+			'What do you think?',
+			'Why do you ask?',
+			'Does the reason matter to you?'
+		]
+	},
+	{
+		pattern: /\b(.*)\b/i,
+		responses: [
+			'Can you tell me more about $1?',
+			'How does that relate to your shopping goals?',
+			'What else would you like to explore?'
+		]
+	}
+];
+
+function reflect(fragment: string): string {
+	return fragment
+		.split(/\b/)
+		.map((token) => {
+			const lower = token.toLowerCase();
+			return reflections.get(lower) ?? token;
+		})
+		.join('');
+}
+
+function choose<T>(items: T[]): T {
+	return items[Math.floor(Math.random() * items.length)];
+}
+
+export function respond(input: string): string {
+	const cleaned = input.trim();
+	if (!cleaned) {
+		return 'Please share what is on your mind about shopping today.';
+	}
+
+	for (const { pattern, responses } of patterns) {
+		const match = cleaned.match(pattern);
+		if (!match) continue;
+
+		let response = choose(responses);
+		response = response.replace(/\$(\d)/g, (_, index: string) => {
+			const capture = match[Number(index)] ?? '';
+			return reflect(capture.toLowerCase());
+		});
+		return response;
+	}
+
+	return 'How can I assist you with your shopping experience?';
+}

--- a/src/lib/components/Chatbot.svelte
+++ b/src/lib/components/Chatbot.svelte
@@ -1,0 +1,337 @@
+<script lang="ts">
+	import { afterUpdate, onMount, tick } from 'svelte';
+	import type { ChatMessage } from '$lib/chat/eliza';
+	import { respond } from '$lib/chat/eliza';
+
+	const panelId = 'eliza-chat-panel';
+	let isOpen = false;
+	let draft = '';
+	let messages: ChatMessage[] = [
+		{
+			from: 'bot',
+			text: 'Hi! I am Eliza, your shopping companion. What brings you in today?'
+		}
+	];
+	let chatWindow: HTMLDivElement | null = null;
+
+	function toggle() {
+		isOpen = !isOpen;
+	}
+
+	async function sendMessage() {
+		const text = draft.trim();
+		if (!text) return;
+
+		messages = [...messages, { from: 'user', text }];
+		draft = '';
+
+		await tick();
+
+		const reply = respond(text);
+		messages = [...messages, { from: 'bot', text: reply }];
+	}
+
+	afterUpdate(() => {
+		if (chatWindow) {
+			chatWindow.scrollTo({ top: chatWindow.scrollHeight, behavior: 'smooth' });
+		}
+	});
+
+	onMount(() => {
+		const handler = (event: KeyboardEvent) => {
+			if (isOpen && event.key === 'Escape') {
+				isOpen = false;
+			}
+		};
+		window.addEventListener('keydown', handler);
+		return () => window.removeEventListener('keydown', handler);
+	});
+</script>
+
+<div class="chat-shell">
+	<button
+		type="button"
+		class={`chat-toggle ${isOpen ? 'chat-toggle--active' : 'chat-toggle--attention'}`}
+		on:click={toggle}
+		aria-expanded={isOpen}
+		aria-controls={panelId}
+	>
+		<div class="chat-toggle__avatar-wrap">
+			<img src="/images/chatbot/eliza-avatar.svg" alt="Eliza assistant avatar" class="chat-toggle__avatar" />
+		</div>
+		{#if isOpen}
+			<span>Close chat</span>
+		{:else}
+			<span>Need a hand?</span>
+		{/if}
+	</button>
+
+	{#if isOpen}
+		<section id={panelId} class="chat-panel" aria-live="polite">
+			<header class="chat-panel__header">Virtual Customer Coach</header>
+			<div bind:this={chatWindow} class="chat-panel__messages">
+				{#each messages as message}
+					<div class={`chat-row chat-row--${message.from}`}>
+						<p class={`chat-bubble chat-bubble--${message.from}`}>{message.text}</p>
+					</div>
+				{/each}
+			</div>
+			<form class="chat-panel__composer" on:submit|preventDefault={sendMessage}>
+				<input
+					type="text"
+					class="chat-input"
+					placeholder="Ask about products, orders, shipping…"
+					bind:value={draft}
+					autocomplete="off"
+				/>
+				<button type="submit" class="chat-send">Send</button>
+			</form>
+		</section>
+	{/if}
+</div>
+
+<style>
+	.chat-shell {
+		pointer-events: none;
+		position: fixed;
+		bottom: 1.5rem;
+		right: 1.5rem;
+		z-index: 50;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 0.5rem;
+	}
+
+	.chat-toggle {
+		position: relative;
+		pointer-events: auto;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		border: none;
+		border-radius: 9999px;
+		padding: 0.5rem 1rem;
+		font-size: 0.875rem;
+		font-weight: 600;
+		cursor: pointer;
+		background-color: var(--color-primary, #c6a0f6);
+		color: var(--color-bg-tertiary, #181926);
+		box-shadow: 0 10px 35px rgba(12, 12, 13, 0.35);
+		transition: transform 0.15s ease, filter 0.15s ease;
+	}
+
+	.chat-toggle::after {
+		content: '';
+		position: absolute;
+		inset: -0.4rem;
+		border-radius: inherit;
+		background: radial-gradient(circle at center, rgba(198, 160, 246, 0.45), transparent 70%);
+		opacity: 0;
+		transform: scale(0.9);
+		transition: opacity 0.2s ease, transform 0.2s ease;
+		z-index: -1;
+	}
+
+	.chat-toggle:hover,
+	.chat-toggle:focus-visible {
+		transform: scale(1.03);
+		filter: brightness(1.05);
+	}
+
+	.chat-toggle:hover::after,
+	.chat-toggle:focus-visible::after {
+		opacity: 1;
+		transform: scale(1.1);
+	}
+
+	.chat-toggle--active {
+		background-color: var(--color-secondary, #b7bdf8);
+	}
+
+	.chat-toggle--attention {
+		animation: chat-pulse 2.5s ease-in-out infinite;
+	}
+
+	.chat-toggle--attention::after {
+		opacity: 0.75;
+		animation: chat-glow 2.5s ease-in-out infinite;
+	}
+
+	.chat-toggle__avatar-wrap {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 2.5rem;
+		width: 2.5rem;
+		border-radius: 9999px;
+		background-color: var(--color-bg-tertiary, #181926);
+		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+		overflow: hidden;
+		transition: width 0.25s ease, height 0.25s ease, transform 0.25s ease;
+	}
+
+	.chat-toggle__avatar {
+		height: 100%;
+		width: 100%;
+		transition: transform 0.25s ease;
+		transform-origin: center;
+	}
+
+	.chat-toggle:hover .chat-toggle__avatar-wrap,
+	.chat-toggle:focus-visible .chat-toggle__avatar-wrap,
+	.chat-toggle--active .chat-toggle__avatar-wrap {
+		height: 4.5rem;
+		width: 4.5rem;
+	}
+
+	.chat-toggle:hover .chat-toggle__avatar,
+	.chat-toggle:focus-visible .chat-toggle__avatar,
+	.chat-toggle--active .chat-toggle__avatar {
+		transform: scale(1.9);
+	}
+
+	.chat-panel {
+		pointer-events: auto;
+		display: flex;
+		flex-direction: column;
+		width: 20rem;
+		overflow: hidden;
+		border-radius: 0.75rem;
+		border: 1px solid var(--color-overlay0, #6e738d);
+		background-color: var(--color-bg-elevated, #363a4f);
+		color: var(--color-text-primary, #cad3f5);
+		box-shadow: 0 20px 45px rgba(8, 8, 12, 0.45);
+	}
+
+	.chat-panel__header {
+		padding: 0.75rem 1rem;
+		font-size: 0.875rem;
+		font-weight: 600;
+		background: linear-gradient(
+			135deg,
+			var(--color-primary, #c6a0f6) 0%,
+			var(--color-accent, #f5bde6) 100%
+		);
+		color: var(--color-bg-tertiary, #181926);
+	}
+
+	.chat-panel__messages {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		max-height: 24rem;
+		overflow-y: auto;
+		padding: 0.75rem 1rem;
+		background-color: var(--color-bg-secondary, #1e2030);
+	}
+
+	.chat-row {
+		display: flex;
+	}
+
+	.chat-row--user {
+		justify-content: flex-end;
+	}
+
+	.chat-row--bot {
+		justify-content: flex-start;
+	}
+
+	.chat-bubble {
+		max-width: 85%;
+		padding: 0.5rem 0.75rem;
+		border-radius: 1rem;
+		font-size: 0.875rem;
+		line-height: 1.4;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+	}
+
+	.chat-bubble--user {
+		background-color: var(--color-primary, #c6a0f6);
+		color: var(--color-bg-tertiary, #181926);
+	}
+
+	.chat-bubble--bot {
+		background-color: var(--color-bg-card, #494d64);
+		color: var(--color-text-primary, #cad3f5);
+	}
+
+	.chat-panel__composer {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		border-top: 1px solid var(--color-overlay0, #6e738d);
+		background-color: var(--color-bg-elevated, #363a4f);
+	}
+
+	.chat-input {
+		flex: 1;
+		height: 2.5rem;
+		padding: 0 0.75rem;
+		border-radius: 9999px;
+		border: 1px solid var(--color-overlay1, #8087a2);
+		background-color: var(--color-bg-secondary, #1e2030);
+		color: var(--color-text-primary, #cad3f5);
+		font-size: 0.875rem;
+	}
+
+	.chat-input:focus-visible {
+		outline: 2px solid var(--color-primary, #c6a0f6);
+		outline-offset: 2px;
+	}
+
+	.chat-send {
+		height: 2.5rem;
+		padding: 0 1.25rem;
+		border-radius: 9999px;
+		border: none;
+		font-size: 0.875rem;
+		font-weight: 600;
+		cursor: pointer;
+		background-color: var(--color-secondary, #b7bdf8);
+		color: var(--color-bg-tertiary, #181926);
+		transition: filter 0.15s ease, transform 0.15s ease;
+	}
+
+	.chat-send:hover,
+	.chat-send:focus-visible {
+		transform: translateY(-1px);
+		filter: brightness(1.05);
+	}
+
+	@keyframes chat-pulse {
+		0%,
+		100% {
+			transform: translateY(0);
+		}
+		50% {
+			transform: translateY(-2px) scale(1.02);
+		}
+	}
+
+	@keyframes chat-glow {
+		0%,
+		100% {
+			opacity: 0.3;
+			transform: scale(1);
+		}
+		50% {
+			opacity: 0.6;
+			transform: scale(1.15);
+		}
+	}
+
+	@media (max-width: 640px) {
+		.chat-shell {
+			right: 1rem;
+			left: 1rem;
+			align-items: stretch;
+		}
+
+		.chat-panel {
+			width: auto;
+		}
+	}
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import favicon from '$lib/assets/favicon.svg';
 	import Header from '$lib/components/Header.svelte';
 	import Footer from '$lib/components/Footer.svelte';
+	import Chatbot from '$lib/components/Chatbot.svelte';
 	// import posthog from 'posthog-js';
 	// import { browser } from '$app/environment';
 	let { children } = $props();
@@ -95,4 +96,6 @@
 	</main>
 
 	<Footer />
+
+	<Chatbot />
 </div>

--- a/static/images/chatbot/eliza-avatar.svg
+++ b/static/images/chatbot/eliza-avatar.svg
@@ -1,0 +1,25 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="120" rx="28" fill="#1E2030"/>
+  <rect x="14" y="70" width="92" height="32" rx="10" fill="#C6A0F6"/>
+  <rect x="20" y="78" width="80" height="16" rx="6" fill="#181926"/>
+  <rect x="28" y="82" width="12" height="8" rx="2" fill="#8BD5CA"/>
+  <rect x="46" y="82" width="12" height="8" rx="2" fill="#8BD5CA"/>
+  <rect x="64" y="82" width="12" height="8" rx="2" fill="#8BD5CA"/>
+  <rect x="82" y="82" width="12" height="8" rx="2" fill="#8BD5CA"/>
+  <circle cx="60" cy="50" r="36" fill="#F4DBD6"/>
+  <ellipse cx="60" cy="92" rx="26" ry="14" fill="#24273A"/>
+  <path d="M33 46C34 34 44 26 60 26C76 26 86 34 87 46" stroke="#181926" stroke-width="4" stroke-linecap="round"/>
+  <path d="M44 58C45.5 60.5 49 64 60 64C71 64 74.5 60.5 76 58" stroke="#181926" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="45" cy="50" r="6" fill="#FFFFFF"/>
+  <circle cx="75" cy="50" r="6" fill="#FFFFFF"/>
+  <circle cx="45" cy="50" r="3" fill="#24273A"/>
+  <circle cx="75" cy="50" r="3" fill="#24273A"/>
+  <rect x="32" y="47" width="22" height="12" rx="6" stroke="#8AADF4" stroke-width="4"/>
+  <rect x="66" y="47" width="22" height="12" rx="6" stroke="#8AADF4" stroke-width="4"/>
+  <rect x="54" y="42" width="12" height="6" rx="3" fill="#8AADF4"/>
+  <path d="M40 71C44 75 50 78 60 78C70 78 76 75 80 71" stroke="#F5BDE6" stroke-width="4" stroke-linecap="round"/>
+  <rect x="50" y="14" width="20" height="14" rx="6" fill="#C6A0F6"/>
+  <rect x="44" y="14" width="32" height="6" rx="3" fill="#F5BDE6"/>
+  <circle cx="37" cy="33" r="6" fill="#C6A0F6"/>
+  <circle cx="83" cy="33" r="6" fill="#C6A0F6"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Eliza-inspired responder module with simple reflection-based scripts
- surface floating chatbot with attention grab, keyboard-friendly avatar, and session chat
- integrate chatbot into root layout so the assistant is available across the app

## Testing
- npm run check (fails: existing TypeScript/a11y diagnostics in repo)