### PR TITLE
fix(ci): load Docker image into local daemon for Meticulous

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_PATH=./data/db.sqlite
+PORT=3000
+NODE_ENV=development

--- a/.github/workflows/meticulous.yaml
+++ b/.github/workflows/meticulous.yaml
@@ -74,6 +74,7 @@ jobs:
           context: .
           tags: my-app:${{ github.sha }}
           push: false
+          load: true
           # Marks the image as a Meticulous build (see note above). Consume it in your
           # Dockerfile with `ARG METICULOUS_BUILD` / `ENV METICULOUS_BUILD=$METICULOUS_BUILD`
           # if you need it at build time (e.g. getStaticProps / static generation).


### PR DESCRIPTION
## Summary
- Add `load: true` to the `docker/build-push-action` step in the Meticulous CI workflow

## Problem
`docker/build-push-action@v6` with `push: false` uses BuildKit which stores the built image only in the BuildKit cache — it does **not** load it into the local Docker daemon. The subsequent Meticulous upload step then fails with:
```
Failed to find Docker image: my-app:<sha>
Docker image 'my-app:<sha>' not found locally.
```

## Fix
`load: true` instructs BuildKit to export the image into the local Docker daemon after building, making it visible to `docker images` and to the Meticulous action.

## Test plan
- [ ] Trigger CI on this PR and verify the Meticulous upload step finds the image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)