### PR TITLE
feat: disable SSR globally

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = false;


### PR DESCRIPTION
## Summary
- Add `src/routes/+layout.ts` with `export const ssr = false` to disable server-side rendering for all pages globally
- Pages render client-side only; `/api/*` server endpoints are unaffected

## Test plan
- [ ] Run `pnpm build` and verify no build errors
- [ ] Confirm pages load correctly in the browser without SSR

🤖 Generated with [Claude Code](https://claude.com/claude-code)