### PR TITLE
feat: Message of the Day + restrict Meticulous to production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Playwright MCP screenshots
+.playwright-mcp/
 data/db.sqlite
 data/olddb.sqllite

--- a/src/lib/components/MessageOfTheDay.svelte
+++ b/src/lib/components/MessageOfTheDay.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	let message = '';
+	let category = '';
+	let timestamp = '';
+	let loading = true;
+	let error = false;
+
+	const CATEGORY_ICONS: Record<string, string> = {
+		wisdom: '🧠',
+		affirmation: '✨',
+		humor: '😄',
+		tip: '💡'
+	};
+
+	async function fetchMotd() {
+		loading = true;
+		error = false;
+		try {
+			const res = await fetch('/api/motd');
+			const data = await res.json();
+			message = data.message;
+			category = data.category;
+			timestamp = new Date(data.timestamp).toLocaleTimeString([], {
+				hour: '2-digit',
+				minute: '2-digit'
+			});
+		} catch {
+			error = true;
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(fetchMotd);
+</script>
+
+<div class="mx-auto max-w-3xl rounded-2xl border border-primary/30 bg-gradient-to-br from-primary/5 to-secondary/5 px-8 py-6 shadow-sm">
+	<div class="mb-3 flex items-center justify-between">
+		<span class="text-xs font-semibold uppercase tracking-widest text-primary">
+			Message of the Day
+		</span>
+		{#if timestamp && !loading}
+			<span class="text-xs text-text-muted">{timestamp}</span>
+		{/if}
+	</div>
+
+	{#if loading}
+		<div class="animate-pulse space-y-2">
+			<div class="h-5 w-3/4 rounded bg-overlay0"></div>
+			<div class="h-5 w-1/2 rounded bg-overlay0"></div>
+		</div>
+	{:else if error}
+		<p class="text-sm text-text-muted italic">Could not load today's message.</p>
+	{:else}
+		<div class="flex items-start gap-3">
+			<span class="mt-0.5 text-2xl leading-none">{CATEGORY_ICONS[category] ?? '⌨️'}</span>
+			<p class="text-base leading-relaxed text-text-primary italic">"{message}"</p>
+		</div>
+	{/if}
+
+	<div class="mt-4 flex justify-end">
+		<button
+			onclick={fetchMotd}
+			class="text-xs text-text-muted transition-colors hover:text-primary disabled:opacity-50"
+			disabled={loading}
+			aria-label="Refresh message"
+		>
+			↻ another one
+		</button>
+	</div>
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,11 +23,13 @@
 </script>
 
 <svelte:head>
-	<script
-		data-recording-token="2UOrzBuoMskqSoBiiMyMlkpqIlWmwhvbYHZ5s4VK"
-		data-is-production-environment={import.meta.env.PROD}
-		src="https://snippet.meticulous.ai/v1/meticulous.js"
-	></script>
+	{#if import.meta.env.PROD}
+		<script
+			data-recording-token="2UOrzBuoMskqSoBiiMyMlkpqIlWmwhvbYHZ5s4VK"
+			data-is-production-environment="true"
+			src="https://snippet.meticulous.ai/v1/meticulous.js"
+		></script>
+	{/if}
 
 	<link rel="icon" href={favicon} />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { APP_CONFIG } from '$lib/config.js';
 	import ProductCard from '$lib/components/ProductCard.svelte';
+	import MessageOfTheDay from '$lib/components/MessageOfTheDay.svelte';
 
 	let featuredProducts: any[] = [];
 	let categories: any[] = [];
@@ -72,6 +73,13 @@
 				</a>
 			</div>
 		</div>
+	</div>
+</section>
+
+<!-- Message of the Day -->
+<section class="bg-bg-primary py-8">
+	<div class="container mx-auto px-4">
+		<MessageOfTheDay />
 	</div>
 </section>
 

--- a/src/routes/api/motd/+server.ts
+++ b/src/routes/api/motd/+server.ts
@@ -1,0 +1,112 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const MESSAGES = [
+	{
+		text: 'Life is too short for mushy membrane keyboards. You deserve better.',
+		category: 'wisdom'
+	},
+	{
+		text: "Your keyboard sounds like rain on a tin roof. Is that... good? It's good.",
+		category: 'affirmation'
+	},
+	{
+		text: 'The clicky switch you bought at midnight was an act of self-care.',
+		category: 'affirmation'
+	},
+	{
+		text: "Somewhere, a rubber dome is crying. That's on you. No regrets.",
+		category: 'humor'
+	},
+	{
+		text: 'Fun fact: 87% of productivity gains can be attributed to a satisfying bottom-out.',
+		category: 'humor'
+	},
+	{
+		text: 'You cannot buy happiness, but you can buy switches. Roughly the same thing.',
+		category: 'wisdom'
+	},
+	{ text: "Today is a great day to lube your stabilizers. You won't regret it.", category: 'tip' },
+	{
+		text: "A 65% keyboard means 65% less keyboard to clean. That's called efficiency.",
+		category: 'wisdom'
+	},
+	{
+		text: "Your coworkers say your keyboard is 'distracting'. Your coworkers are jealous.",
+		category: 'humor'
+	},
+	{
+		text: 'Hot take: the best keycap colorway is whichever one you currently cannot afford.',
+		category: 'humor'
+	},
+	{
+		text: 'Every group buy you missed has made you stronger. Probably.',
+		category: 'affirmation'
+	},
+	{
+		text: 'A well-built keyboard outlasts trends, jobs, and possibly relationships. Choose wisely.',
+		category: 'wisdom'
+	},
+	{
+		text: "Gasket mount wasn't a buzzword. It was a prophecy.",
+		category: 'wisdom'
+	},
+	{
+		text: 'The sound of linears: smooth. The sound of tactiles: satisfying. The sound of clickies: controversial.',
+		category: 'humor'
+	},
+	{
+		text: "You didn't buy a $300 keyboard. You invested in your fingers' future.",
+		category: 'affirmation'
+	},
+	{
+		text: 'Desk mats: because your keyboard deserves a better landing pad than your dignity.',
+		category: 'humor'
+	},
+	{
+		text: 'Clack responsibly. Your open-plan office depends on it.',
+		category: 'tip'
+	},
+	{
+		text: "There is no such thing as 'too many keyboards'. That's a myth spread by Big Membrane.",
+		category: 'wisdom'
+	},
+	{
+		text: "The right switch is a personal journey. The wrong switch is someone else's endgame.",
+		category: 'wisdom'
+	},
+	{
+		text: "Legends never fade — unless you're using shine-through PBT. Then they might.",
+		category: 'humor'
+	},
+	{
+		text: 'GMK lead times build character. Lots of character. So much character.',
+		category: 'affirmation'
+	},
+	{
+		text: 'Pro tip: the loudest keyboard in the room is always the best keyboard in the room.',
+		category: 'tip'
+	},
+	{
+		text: "You're not addicted to keyboards. You're just very enthusiastic about typing accuracy.",
+		category: 'affirmation'
+	},
+	{
+		text: 'South-facing RGB is an aesthetic choice. North-facing RGB is a lifestyle.',
+		category: 'wisdom'
+	},
+	{
+		text: "If your keyboard doesn't spark joy, it's time to Marie Kondo your switch collection.",
+		category: 'tip'
+	}
+];
+
+export const GET: RequestHandler = async () => {
+	const message = MESSAGES[Math.floor(Math.random() * MESSAGES.length)];
+
+	return json({
+		timestamp: new Date().toISOString(),
+		message: message.text,
+		category: message.category
+	});
+};


### PR DESCRIPTION
## Summary
- Adds a `/api/motd` endpoint that returns a random keyboard-themed message (25 messages across wisdom/affirmation/humor/tip categories) with a timestamp
- Adds a `MessageOfTheDay` component on the homepage between the hero and the category grid, with a refresh button to fetch a new message
- Meticulous recording snippet is now wrapped in `{#if import.meta.env.PROD}` so it only loads in serve/production mode, not during `npm run dev`

## Test plan
- [ ] Visit homepage in dev — Message of the Day box appears with a message and category emoji
- [ ] Click "↻ another one" — a new message loads from the API
- [ ] Verify `/api/motd` returns `{ timestamp, message, category }` 
- [ ] Run `npm run dev` and confirm Meticulous script tag is absent from the page source
- [ ] Run `npm run build && npm run preview` and confirm Meticulous script tag is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)