### PR TITLE
revert: restore original Meticulous script tag

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,13 +23,11 @@
 </script>
 
 <svelte:head>
-	{#if import.meta.env.PROD}
-		<script
-			data-recording-token="2UOrzBuoMskqSoBiiMyMlkpqIlWmwhvbYHZ5s4VK"
-			data-is-production-environment="true"
-			src="https://snippet.meticulous.ai/v1/meticulous.js"
-		></script>
-	{/if}
+	<script
+		data-recording-token="2UOrzBuoMskqSoBiiMyMlkpqIlWmwhvbYHZ5s4VK"
+		data-is-production-environment={import.meta.env.PROD}
+		src="https://snippet.meticulous.ai/v1/meticulous.js"
+	></script>
 
 	<link rel="icon" href={favicon} />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary
- Reverts the `{#if import.meta.env.PROD}` guard added in #18 — the conditional injection approach caused Meticulous to not load at all (Svelte's `<svelte:head>` creates script elements via template cloning, which browsers don't execute)
- Restores the original unconditional `<script>` tag with `data-is-production-environment={import.meta.env.PROD}`, letting Meticulous handle env-specific behaviour via its own attribute

## Test plan
- [ ] `pnpm docker:build && pnpm docker:run` — Meticulous records sessions
- [ ] `npm run dev` — Meticulous loads but `data-is-production-environment="false"` so recordings are not uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)